### PR TITLE
Fix UI layering so HUD remains above WebGL canvas

### DIFF
--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -13,6 +13,29 @@
             color: #fff;
         }
 
+        #game-root {
+            position: fixed;
+            inset: 0;
+            z-index: 0;
+        }
+
+        #game-root canvas {
+            display: block;
+            width: 100%;
+            height: 100%;
+        }
+
+        #ui-layer {
+            position: fixed;
+            inset: 0;
+            pointer-events: none;
+            z-index: 10;
+        }
+
+        #ui-layer > * {
+            pointer-events: auto;
+        }
+
         #log {
             position: absolute;
             top: 10px;
@@ -26,7 +49,10 @@
     </style>
 </head>
 <body>
-    <div id="log"></div>
+    <div id="game-root"></div>
+    <div id="ui-layer">
+        <div id="log"></div>
+    </div>
 
     <!-- 1) Three.js from a CDN (global THREE object) -->
     <script src="https://cdn.jsdelivr.net/npm/three@0.156.1/build/three.min.js"></script>

--- a/wwwroot/world.js
+++ b/wwwroot/world.js
@@ -21,7 +21,15 @@ export class World {
         // 4) Renderer
         this.renderer = new THREE.WebGLRenderer({ antialias: true });
         this.renderer.setSize(window.innerWidth, window.innerHeight);
-        document.body.appendChild(this.renderer.domElement);
+
+        const container = document.getElementById('game-root');
+        if (container) {
+            container.innerHTML = '';
+            container.appendChild(this.renderer.domElement);
+        }
+        else {
+            document.body.appendChild(this.renderer.domElement);
+        }
 
         // 5) chunk meshes
         this.chunkMeshes = new Map();


### PR DESCRIPTION
## Summary
- add a dedicated container for the WebGL renderer so UI elements stay visible on reload
- ensure the HUD layer remains above the canvas while keeping interactive elements clickable
- update the world setup to mount the renderer into the new container

## Testing
- dotnet run --urls http://0.0.0.0:5000

------
https://chatgpt.com/codex/tasks/task_e_68d60e5431fc832cb26f1a3a1a66865e