### PR TITLE
Allow players to select stat upgrades and add attack speed

### DIFF
--- a/Libraries/Singularity.Core/PlayerModels.cs
+++ b/Libraries/Singularity.Core/PlayerModels.cs
@@ -47,6 +47,8 @@ public sealed class PlayerStats
     public int Attack { get; set; } = 10;
     public int MaxHealth { get; set; } = 100;
     public int CurrentHealth { get; set; } = 100;
+    public double AttackSpeed { get; set; } = 1.0;
+    public int UnspentStatPoints { get; set; }
 }
 
 public sealed class PlayerStatsDto
@@ -57,6 +59,8 @@ public sealed class PlayerStatsDto
     public int Attack { get; set; }
     public int MaxHealth { get; set; }
     public int CurrentHealth { get; set; }
+    public double AttackSpeed { get; set; }
+    public int UnspentStatPoints { get; set; }
 }
 
 public sealed class PlayerAbilityState
@@ -86,4 +90,12 @@ public sealed class AbilityDefinition
     public double DamageMultiplier { get; init; }
     public int UnlockLevel { get; init; }
     public bool ResetOnLevelUp { get; init; }
+    public bool ScalesWithAttackSpeed { get; init; }
+}
+
+public sealed class PlayerStatUpgradeOption
+{
+    public string Id { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string Description { get; init; } = string.Empty;
 }

--- a/wwwroot/abilities.js
+++ b/wwwroot/abilities.js
@@ -8,7 +8,8 @@ export const ABILITY_DEFAULTS = {
         cooldown: 1.6,
         unlocked: true,
         resetOnLevelUp: false,
-        autoCast: true
+        autoCast: true,
+        scalesWithAttackSpeed: true
     },
     instantStrike: {
         name: 'Skyburst Strike',

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -238,6 +238,104 @@
             opacity: 0.85;
         }
 
+        #upgradeOverlay {
+            position: absolute;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: rgba(8, 12, 20, 0.72);
+            backdrop-filter: blur(12px);
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.25s ease;
+            z-index: 50;
+        }
+
+        #upgradeOverlay[data-visible="true"] {
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        #upgradePanel {
+            min-width: 320px;
+            max-width: 420px;
+            padding: 24px 28px;
+            border-radius: 20px;
+            background: rgba(22, 28, 42, 0.92);
+            box-shadow: 0 26px 60px rgba(0, 0, 0, 0.55);
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            text-align: center;
+        }
+
+        #upgradePanel h3 {
+            margin: 0;
+            font-size: 16px;
+            letter-spacing: 0.22em;
+            text-transform: uppercase;
+        }
+
+        #upgradeRemaining {
+            font-size: 13px;
+            letter-spacing: 0.12em;
+            opacity: 0.75;
+        }
+
+        #upgradeOptions {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .upgrade-option {
+            border: 1px solid rgba(160, 210, 255, 0.25);
+            border-radius: 14px;
+            background: rgba(50, 76, 118, 0.55);
+            color: inherit;
+            font: inherit;
+            padding: 14px 16px;
+            text-align: left;
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            cursor: pointer;
+            transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+        }
+
+        .upgrade-option:hover:not(:disabled) {
+            transform: translateY(-2px);
+            border-color: rgba(200, 244, 255, 0.6);
+            background: rgba(76, 114, 168, 0.65);
+        }
+
+        .upgrade-option:disabled {
+            opacity: 0.45;
+            cursor: default;
+        }
+
+        .upgrade-name {
+            font-size: 15px;
+            letter-spacing: 0.18em;
+            text-transform: uppercase;
+        }
+
+        .upgrade-desc {
+            font-size: 13px;
+            opacity: 0.78;
+        }
+
+        #upgradeHint {
+            font-size: 12px;
+            letter-spacing: 0.1em;
+            opacity: 0.7;
+        }
+
+        #upgradeOverlay[data-processing="true"] .upgrade-option {
+            pointer-events: none;
+        }
+
         #levelToast {
             position: absolute;
             top: 18%;
@@ -268,6 +366,7 @@
                 <h2>Adventurer</h2>
                 <div class="stat"><span>Level</span><span id="levelValue">1</span></div>
                 <div class="stat"><span>Attack</span><span id="attackValue">8</span></div>
+                <div class="stat"><span>Attack Speed</span><span id="attackSpeedValue">1.00x</span></div>
                 <div class="stat"><span>Health</span><span id="healthValue">120 / 120</span></div>
                 <div class="xp-bar"><div id="xpFill"></div></div>
                 <div id="xpText">0 / 80 XP</div>
@@ -285,6 +384,14 @@
             <div class="debug-row"><span>Nearest Dist</span><span id="debugDistance">—</span></div>
             <div class="debug-row"><span>Target</span><span id="debugTarget">None</span></div>
             <div class="debug-row"><span>Target Dist</span><span id="debugTargetDistance">—</span></div>
+        </div>
+    </div>
+    <div id="upgradeOverlay" data-visible="false" data-processing="false">
+        <div id="upgradePanel">
+            <h3>Choose Upgrade</h3>
+            <div id="upgradeRemaining"></div>
+            <div id="upgradeOptions"></div>
+            <div id="upgradeHint"></div>
         </div>
     </div>
     <div id="levelToast">Level Up!</div>

--- a/wwwroot/network.js
+++ b/wwwroot/network.js
@@ -192,6 +192,13 @@ export class Network {
         this.send(payload);
     }
 
+    sendStatUpgrade(statId) {
+        if (!this.isOpen() || !statId) {
+            return;
+        }
+        this.send({ type: 'upgradeStat', statId });
+    }
+
     send(payload) {
         if (!this.isOpen()) {
             return;

--- a/wwwroot/player.js
+++ b/wwwroot/player.js
@@ -32,6 +32,7 @@ export class Player {
         this.abilityRanges = new Map();
         this.primaryAbilityId = null;
         this.debugInfo = this.createDebugInfo();
+        this.stats = { attackSpeed: 1, unspentStatPoints: 0 };
 
         this.initInputListeners();
     }
@@ -128,7 +129,11 @@ export class Player {
                 continue;
             }
 
-            const fallbackCooldown = defaults.cooldown ?? 1.5;
+            let fallbackCooldown = defaults.cooldown ?? 1.5;
+            if (defaults.scalesWithAttackSpeed) {
+                const attackSpeed = Math.max(0.1, this.stats?.attackSpeed ?? 1);
+                fallbackCooldown = fallbackCooldown / attackSpeed;
+            }
             this.network.sendAbilityUse(ability.id, targetInRange.id);
 
             ability.pending = true;
@@ -157,6 +162,15 @@ export class Player {
         }
 
         this.debugInfo = debugInfo;
+    }
+
+    setStats(stats = {}) {
+        const attackSpeed = typeof stats.attackSpeed === 'number' ? stats.attackSpeed : (this.stats?.attackSpeed ?? 1);
+        const unspent = typeof stats.unspentStatPoints === 'number' ? stats.unspentStatPoints : (this.stats?.unspentStatPoints ?? 0);
+        this.stats = {
+            attackSpeed,
+            unspentStatPoints: unspent
+        };
     }
 
     sendMovementToServerIfNeeded() {


### PR DESCRIPTION
## Summary
- add an attack speed stat and unspent point tracking to player state, including stat upgrade options and faster auto attack cooldowns
- expose the new stat upgrade flow over the websocket so clients can request upgrades and receive available options
- refresh the client HUD with attack speed, an upgrade selection panel, and attack speed-aware ability cooldowns

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d772aaf780832c8d6fdd889abbe9ff