### PR TITLE
Ensure Three.js canvas preserves UI overlay

### DIFF
--- a/wwwroot/world.js
+++ b/wwwroot/world.js
@@ -41,11 +41,13 @@ export class World {
         this.renderer.setPixelRatio(window.devicePixelRatio ?? 1);
 
         const existingCanvas = document.getElementById('gameCanvas');
-        if (existingCanvas && existingCanvas.parentElement) {
-            existingCanvas.parentElement.removeChild(existingCanvas);
-        }
         this.renderer.domElement.id = 'gameCanvas';
-        document.body.appendChild(this.renderer.domElement);
+
+        if (existingCanvas && existingCanvas.parentElement) {
+            existingCanvas.replaceWith(this.renderer.domElement);
+        } else {
+            document.body.prepend(this.renderer.domElement);
+        }
 
         const aspect = window.innerWidth / window.innerHeight;
         this.camera = new THREE.PerspectiveCamera(60, aspect, 0.1, 400);


### PR DESCRIPTION
## Summary
- replace the placeholder canvas in-place when initializing the Three.js renderer so UI overlays keep their stacking order
- fall back to prepending the renderer canvas when no placeholder exists

## Testing
- dotnet run

------
https://chatgpt.com/codex/tasks/task_e_68dc77a7d2ac832c86f21f556ee6cea6